### PR TITLE
[IMP] Added htop and packages needed to avoid https://urllib3.readthe…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get update -q && apt-get upgrade -q \
     libsasl2-dev \
     openssl \
     libffi-dev \
-    libssl-dev
+    libssl-dev \
+    vim-nox
 RUN cd /tmp && wget -q https://bootstrap.pypa.io/get-pip.py && python get-pip.py
 RUN pip install --upgrade pyopenssl ndg-httpsclient pyasn1
 RUN pip install PyGithub

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,13 @@ RUN apt-get update -q && apt-get upgrade -q \
     multitail \
     postgresql-client \
     locate \
-    unzip
-RUN cd /tmp && wget -q https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py && python get-pip.py
-RUN pip install PyGithub && pip install redis
+    unzip \
+    htop \
+    libsasl2-dev \
+    openssl \
+    libffi-dev \
+    libssl-dev
+RUN cd /tmp && wget -q https://bootstrap.pypa.io/get-pip.py && python get-pip.py
+RUN pip install --upgrade pyopenssl ndg-httpsclient pyasn1
+RUN pip install PyGithub redis
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ RUN apt-get update -q && apt-get upgrade -q \
     libssl-dev
 RUN cd /tmp && wget -q https://bootstrap.pypa.io/get-pip.py && python get-pip.py
 RUN pip install --upgrade pyopenssl ndg-httpsclient pyasn1
-RUN pip install PyGithub redis
+RUN pip install PyGithub
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*


### PR DESCRIPTION
…docs.org/en/latest/security.html#insecureplatformwarning.

While they are installing the warn is shown, but after they are installed (see PyGithub and redis installation as an example) the warn does not show:

![no_warn](http://i.imgur.com/xcEQsio.png)