### PR TITLE
[FIX] Adding more locales to the generation list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:14.04
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 
-RUN locale-gen "en_US.UTF-8" "fr_FR.UTF-8"
+RUN locale-gen "en_US.UTF-8" "fr_FR.UTF-8" "es_MX.UTF-8" \
+    "es_PA.UTF-8" "es_VE.UTF-8" "es_GT.UTF-8"
 ENV LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8" LC_ALL="en_US.UTF-8" \
     PYTHONIOENCODING="UTF-8" TERM="xterm" DEBIAN_FRONTEND="noninteractive"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 
 RUN locale-gen "en_US.UTF-8" "fr_FR.UTF-8" "es_MX.UTF-8" \
-    "es_PA.UTF-8" "es_VE.UTF-8" "es_GT.UTF-8"
+    "es_PA.UTF-8" "es_VE.UTF-8" "es_GT.UTF-8" "es_PE.UTF-8"
 ENV LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8" LC_ALL="en_US.UTF-8" \
     PYTHONIOENCODING="UTF-8" TERM="xterm" DEBIAN_FRONTEND="noninteractive"
 


### PR DESCRIPTION
Adding "es_MX.UTF-8" "es_PA.UTF-8" "es_VE.UTF-8" "es_GT.UTF-8" locales to the generation list so that Odoo can have them available for tests.

This PR resolves #22.