### PR TITLE
[FIX] Supervisor should be installed as a python package

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -24,7 +24,6 @@ DPKG_DEPENDS="bzr \
               locate \
               lsof \
               multitail \
-              supervisor \
               tmux \
               unzip \
               vim \
@@ -47,7 +46,8 @@ PIP_DEPENDS="pyopenssl \
              PyGithub \
              merge-requirements \
              pip-tools \
-             click"
+             click \
+             supervisor"
 PIP_DPKG_BUILD_DEPENDS="libpq-dev \
                         python-dev \
                         libffi-dev \


### PR DESCRIPTION
As a python package it should be installed using pip and with this we avoid the need of making changes in all the builds that depends on this