### PR TITLE
[IMP] Install Python 2.7.12

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -12,6 +12,8 @@ PSQL_UPSTREAM_KEY="https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 TRUSTY_REPO="deb http://archive.ubuntu.com/ubuntu/ trusty main universe multiverse"
 TRUSTY_UPDATES_REPO="deb http://archive.ubuntu.com/ubuntu/ trusty-updates main universe multiverse"
 TRUSTY_SECURITY_REPO="deb http://archive.ubuntu.com/ubuntu/ trusty-security main universe multiverse"
+PYTHON_PPA_REPO="deb http://ppa.launchpad.net/fkrull/deadsnakes-python2.7/ubuntu trusty main"
+PYTHON_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xFF3997E83CD969B409FB24BC5BB92C09DB82666C"
 DPKG_PRE_DEPENDS="wget ca-certificates"
 DPKG_DEPENDS="bzr \
               git \
@@ -88,6 +90,9 @@ apt-get install ${DPKG_PRE_DEPENDS}
 # This will put postgres's upstream repo for us to install a newer
 # postgres because our image is so old
 add_custom_aptsource "${PSQL_UPSTREAM_REPO}" "${PSQL_UPSTREAM_KEY}"
+
+# Add python repo so we can use the latest 2.7 version
+add_custom_aptsource "${PYTHON_PPA_REPO}" "${PYTHON_PPA_KEY}"
 
 # Release the apt monster!
 apt-get update


### PR DESCRIPTION
@moylop260 I didn't want to use this ppa because what it says in the [page](https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes-python2.7/+packages)

![a](http://screenshots.vauxoo.com/tulio/00103832916-rHisxm6rIP.jpg)

Even the author [says](https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes-python2.7) that should not be used in the long term:

![b](http://screenshots.vauxoo.com/tulio/00110532916-fEqYzNZYmr.jpg)

Besides that I built the base image, Odoo one and one extra just to test if it installed properly:

![d](http://screenshots.vauxoo.com/tulio/00132132916-ElsRPqgBMq.jpg)

And as far as I can see it installed properly:

![e](http://screenshots.vauxoo.com/tulio/00140432916-jGrbzRZyKF.jpg)

I tried to compile the one from the [Python page](https://www.python.org/ftp/python/2.7.12/) but I had a lot of issues installing dependencies later, this would require a little more R&D to have it working properly, in the other hand it seems to be updated with the latest version:

![f](http://screenshots.vauxoo.com/tulio/00220132916-iJSEb0iHxx.jpg)

![g](http://screenshots.vauxoo.com/tulio/00234832916-uPANPhbnmH.jpg)

Regards.