### PR TITLE
[FIX] Add missing dependency

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -53,6 +53,7 @@ PIP_DEPENDS="pyopenssl \
 PIP_DPKG_BUILD_DEPENDS="libpq-dev \
                         python-dev \
                         libffi-dev \
+                        libssl-dev \
                         gcc"
 
 # Dpkg, please always install configurations from upstream, be fast


### PR DESCRIPTION
This solves this error:

![a](http://screenshots.vauxoo.com/tulio/19052900517-IlnUc3zUpM.jpg)

Since the [cryptography package needs](https://cryptography.io/en/latest/installation/#building-cryptography-on-linux) libssl-dev to compile properly we need to add this to avoid further errors