### PR TITLE
[IMP] Add full support fot python 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
 script:
   - for dfile in `find $TRAVIS_BUILD_DIR -name 'Dockerfile' -not -path "./.git/*"`; do echo " ===== [ CHECKING $dfile ] ===== "; dockerlint $dfile; if [ $? -ne 0 ]; then echo " ----- [ FINISHED IN ERROR ] ----- "; fi; echo ""; done
   - git clone https://github.com/vauxoo/docker-odoo-image.git ${TRAVIS_BUILD_DIR}/docker-odoo-image
-  - cd ${TRAVIS_BUILD_DIR} && docker build --rm -t vauxoo/docker-ubuntu-base:16.04 .
-  - cd ${TRAVIS_BUILD_DIR}/docker-odoo-image/odoo100 && docker build --rm -t vauxoo/odoo-100-image:latest .
+  - cd ${TRAVIS_BUILD_DIR} && docker build --rm -t vauxoo/docker-ubuntu-base:16.04-p3 .
+  - cd ${TRAVIS_BUILD_DIR}/docker-odoo-image/odoo110 && docker build --rm -t vauxoo/odoo-110-image:latest .
 
 # TODO: Add docker push
 #after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 
 RUN apt-get update \
-    && apt-get install locales language-pack-es \
+    && apt-get install locales language-pack-es -y \
     && locale-gen "en_US.UTF-8" "fr_FR.UTF-8" "es_MX.UTF-8" \
     "es_PA.UTF-8" "es_VE.UTF-8" "es_GT.UTF-8" "es_PE.UTF-8" \
     "es_ES.UTF-8"

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -34,9 +34,9 @@ DPKG_DEPENDS="bzr \
               postgresql-client \
               postgresql-common \
               python \
-              python-setuptools"
-DPKG_UNNECESSARY="libpython3.4 \
-                  libpython3.4-minimal"
+              python-setuptools \
+              python3"
+DPKG_UNNECESSARY=""
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS="pyopenssl \
@@ -46,10 +46,9 @@ PIP_DEPENDS="pyopenssl \
              PyGithub \
              merge-requirements \
              pip-tools \
-             click \
-             supervisor"
+             click"
 PIP_DPKG_BUILD_DEPENDS="libpq-dev \
-                        python-dev \
+                        python3-dev \
                         libffi-dev \
                         libssl-dev \
                         gcc"
@@ -98,7 +97,8 @@ apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
 py_download_execute https://bootstrap.pypa.io/get-pip.py
 
 # Install python dependencies
-pip install ${PIP_OPTS} ${PIP_DEPENDS}
+pip3 install ${PIP_OPTS} ${PIP_DEPENDS}
+pip2 install supervisor
 
 # Remove build depends for pip and unnecessary packages
 apt-get purge ${PIP_DPKG_BUILD_DEPENDS} ${DPKG_UNNECESSARY}

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -20,4 +20,5 @@ function add_custom_aptsource(){
 function py_download_execute(){
     URL="${1}"
     wget -qO- "${URL}" | python
+    wget -qO- "${URL}" | python3
 }


### PR DESCRIPTION
- Added dev files for python 3 so the dependencies can be built without any issues

- pip2 and 3 support because supervisor is not p3 compilant yet

This image should be migrated to Ubuntu 18.04 as soon as it is available to be used with Odoo 11 when it it released.