### PR TITLE
[FIX] Filename of the PG_LOG_PATH environment variable

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -122,7 +122,7 @@ find /usr/local/lib/python2.7/dist-packages/github/tests -type f -print0 | xargs
 # Configure the path for the postgres logs
 mkdir -p /var/log/pg_log
 chmod 0757 /var/log/pg_log/
-echo -e "export PG_LOG_PATH=/var/log/pg_log\n" | tee -a /etc/bash.bashrc
+echo -e "export PG_LOG_PATH=/var/log/pg_log/postgresql.log\n" | tee -a /etc/bash.bashrc
 
 cat >> /etc/postgresql-common/common-vauxoo.conf << EOF
 listen_addresses = '*'


### PR DESCRIPTION
The configuration file of postgresql is using:
log_directory='/var/log/pg_log'
log_filename='postgresql.log'

Then the PG_LOG_PATH should be `/var/log/pg_log/postgresql.log`

cc @ruiztulio @hugho-ad @Angelfentanez 


=========IMPORTANT=========
Delete the branch after merge it