### PR TITLE
[IMP] Dockerfile: Use 'C' collation by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && locale-gen "en_US.UTF-8" "fr_FR.UTF-8" "es_MX.UTF-8" \
     "es_PA.UTF-8" "es_VE.UTF-8" "es_GT.UTF-8" "es_PE.UTF-8" \
     "es_ES.UTF-8"
-ENV LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8" LC_ALL="en_US.UTF-8" \
+ENV LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8" LC_ALL="en_US.UTF-8" LC_COLLATE="C" \
     PYTHONIOENCODING="UTF-8" TERM="xterm" DEBIAN_FRONTEND="noninteractive"
 
 COPY scripts/*.sh /usr/share/vx-docker-internal/ubuntu-base/


### PR DESCRIPTION
This is intended to cause all created databases to use the 'C' collation
by default, so their indexing is faster. For more info, see:
https://github.com/odoo/odoo/commit/276ea817f4675a73576905edbc2a4567570ac206