### PR TITLE
[FIX] Remove mercurial installed from apr in favor of the pip one to avoid error on install

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -15,7 +15,6 @@ PSQL_UPSTREAM_KEY="https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 DPKG_PRE_DEPENDS="wget ca-certificates"
 DPKG_DEPENDS="bzr \
               git \
-              mercurial \
               bash-completion \
               apt-transport-https \
               curl \
@@ -47,7 +46,8 @@ PIP_DEPENDS="pyopenssl \
              merge-requirements \
              pip-tools \
              click \
-             supervisor"
+             supervisor \
+             mercurial"
 PIP_DPKG_BUILD_DEPENDS="libpq-dev \
                         python-dev \
                         libffi-dev \


### PR DESCRIPTION
@moylop260 This is in part to help fix this:

![a](http://screenshots.vauxoo.com/tulio/11404731818-ldUUbH7EnW.jpg)

[In this build](https://hub.docker.com/r/vauxoo/odoo-100-image/builds/b7fuloywhydpqc9agfajpf5/)

I'm also fixing the 12.0 image, but that's another PR