### PR TITLE
[IMP] Add GeoLite2-City

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -12,6 +12,7 @@ BIONIC_UPDATES_REPO="deb http://archive.ubuntu.com/ubuntu/ bionic-updates main u
 BIONIC_SECURITY_REPO="deb http://archive.ubuntu.com/ubuntu/ bionic-security main universe multiverse"
 PSQL_UPSTREAM_REPO="deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main"
 PSQL_UPSTREAM_KEY="https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+GEOIP_DB_URL="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz"
 DPKG_PRE_DEPENDS="wget ca-certificates gnupg2"
 DPKG_DEPENDS="bzr \
               git \
@@ -104,6 +105,9 @@ pip install ${PIP_OPTS} ${PIP_DEPENDS}
 # Remove build depends for pip and unnecessary packages
 apt-get purge ${PIP_DPKG_BUILD_DEPENDS} ${DPKG_UNNECESSARY}
 apt-get autoremove
+
+# Install GeoIP database
+geoip_install "${GEOIP_DB_URL}"
 
 # Final cleaning
 find /tmp -type f -print0 | xargs -0r rm -rf

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -22,3 +22,13 @@ function py_download_execute(){
     wget -qO- "${URL}" | python
     wget -qO- "${URL}" | python3
 }
+
+# Helper function to install GeoLite2
+function geoip_install(){
+    URL="${1}"
+    DIR="$( mktemp -d )"
+    wget -qO- "${URL}" | tar -xz -C "${DIR}/"
+    mkdir -p /usr/share/GeoIP/
+    mv "$(find ${DIR} -name "GeoLite2-City.mmdb")" "/usr/share/GeoIP/GeoLite2-City.mmdb"
+    rm -rf "${DIR}"
+}


### PR DESCRIPTION
- Adding this to the base image will allow us to have it available to all Odoo instances that use Ubuntu 18.04 (12.0 only so far, but the upcoming 13 will have it too)
- This dependency is used for geolocation in the web pages


@moylop260 For the 11.0 we did the changes directly to the Odoo image because we were in a rush (and for the images based in 16.04 we won't use another Odoo version), but this will leave the dependency available for upcoming Odoo versions 