### PR TITLE
[IMP] Install restic

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -14,6 +14,7 @@ PSQL_UPSTREAM_REPO="deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg mai
 JAVA_UPSTREAM_REPO="deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu xenial main"
 JAVA_UPSTREAM_KEY="http://keyserver.ubuntu.com/pks/lookup?search=0xda1a4a13543b466853baf164eb9b1d8886f44e2a&op=get"
 PSQL_UPSTREAM_KEY="https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+RESTIC_URL="https://github.com/restic/restic/releases/download/v0.9.5/restic_0.9.5_linux_amd64.bz2"
 DPKG_PRE_DEPENDS="wget ca-certificates"
 DPKG_DEPENDS="bzr \
               git \
@@ -37,7 +38,8 @@ DPKG_DEPENDS="bzr \
               postgresql-common \
               python \
               python-setuptools \
-              python3"
+              python3 \
+              bzip2"
 DPKG_UNNECESSARY=""
 PIP_OPTS="--upgrade \
           --no-cache-dir"
@@ -100,6 +102,9 @@ apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
 
 # Get pip from upstream because is lighter
 py_download_execute https://bootstrap.pypa.io/get-pip.py
+
+# Install restic
+install_restic ${RESTIC_URL}
 
 # Install python dependencies
 pip3 install ${PIP_OPTS} ${PIP_DEPENDS}

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -22,3 +22,11 @@ function py_download_execute(){
     wget -qO- "${URL}" | python
     wget -qO- "${URL}" | python3
 }
+
+function install_restic(){
+    URL="${1}"
+    DIR="$( mktemp -d )"
+    wget -q "${URL}" -O "${DIR}/restic.bz2"
+    bunzip2 "${DIR}/restic.bz2"
+    mv "${DIR}/restic" /usr/bin && chmod +x /usr/bin/restic
+}


### PR DESCRIPTION
- Restic will be used in orchest to retreive the backup list from our restic hhttp server and gieve the users the posibility to decide which backup they want to use
- We are evaluating to add this as a feature in all instances: backup the instance from the instance itself and upload the backup to restic. When a backup is uploaded to restic in available from all locations that have the credentials, the backup don't need to be compressed (reduce io an cpu consumption)
- As we work in this we will evaluate adding this to other images