### PR TITLE
[REF] build: Install libmysqlclient-dev

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -37,7 +37,8 @@ DPKG_DEPENDS="bzr \
               postgresql-client \
               postgresql-common \
               python \
-              python-setuptools"
+              python-setuptools \
+              libmysqlclient-dev"
 DPKG_UNNECESSARY="libpython3.4 \
                   libpython3.4-minimal"
 PIP_OPTS="--upgrade \


### PR DESCRIPTION
This package is required for OCA projects used in Vauxoo.
E.g. https://github.com/OCA/reporting-engine

- [ ] If it is approved then make PR to another distributions