### PR TITLE
[REF] build: Install libmysqlclient-dev

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -39,7 +39,8 @@ DPKG_DEPENDS="bzr \
               python \
               python-setuptools \
               python3 \
-              bzip2"
+              bzip2 \
+              libmysqlclient-dev"
 DPKG_UNNECESSARY=""
 PIP_OPTS="--upgrade \
           --no-cache-dir"


### PR DESCRIPTION
This package is required for OCA projects used in Vauxoo.
E.g. https://github.com/OCA/reporting-engine

FW https://github.com/Vauxoo/docker-ubuntu-base/pull/65