### PR TITLE
[REF] build: Install libmysqlclient-dev

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -35,7 +35,8 @@ DPKG_DEPENDS="bzr \
               postgresql-client \
               postgresql-common \
               python \
-              python-setuptools"
+              python-setuptools \
+              libmysqlclient-dev"
 DPKG_UNNECESSARY="libpython3.4 \
                   libpython3.4-minimal"
 PIP_OPTS="--upgrade \


### PR DESCRIPTION
This package is required for OCA projects used in Vauxoo.
E.g. https://github.com/OCA/reporting-engine

FW https://github.com/Vauxoo/docker-ubuntu-base/pull/65