### PR TITLE
[FIX] Set the proper binary fot python .

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -101,6 +101,9 @@ apt-get update
 apt-get upgrade
 apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
 
+# Before doing anything else let's set the proper binary for python
+update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
 # Get pip from upstream because is lighter
 py_download_execute https://bootstrap.pypa.io/get-pip.py
 


### PR DESCRIPTION
By default the ubuntu:20.04 image have no python directly have them as python2 and python3, but we need a default version so wverything works properly