### PR TITLE
[FIX] Dockerfile: add env var to avoid numpy weird errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update \
     && apt-get install language-pack-es -y \
     && locale-gen "en_US.UTF-8" "fr_FR.UTF-8"
 ENV LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8" LC_ALL="en_US.UTF-8" LC_COLLATE="C" \
-    PYTHONIOENCODING="UTF-8" TERM="xterm" DEBIAN_FRONTEND="noninteractive"
+    PYTHONIOENCODING="UTF-8" TERM="xterm" DEBIAN_FRONTEND="noninteractive" \
+    OPENBLAS_NUM_THREADS=1
 
 COPY scripts/*.sh /usr/share/vx-docker-internal/ubuntu-base/
 RUN bash /usr/share/vx-docker-internal/ubuntu-base/build-image.sh

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -109,7 +109,7 @@ apt-get upgrade
 apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
 
 # Get pip from upstream because is lighter
-py_download_execute https://bootstrap.pypa.io/get-pip.py
+py_download_execute https://bootstrap.pypa.io/pip/2.7/get-pip.py
 
 # Let's keep this version ultil the bugs get fixed
 pip install --upgrade pip==8.1.1


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently, if numpy is available in the modules even if you are not using it
Odoo try to compile and the system is down only for a type of processor

Currently we know 2 server reproducing the error:

-    B&F-production
-    Runbot

More info about:

https://github.com/numpy/numpy/issues/17674
https://github.com/numpy/numpy/pull/17759

It is reproducing in the following MR:

https://git.vauxoo.com/vauxoo/lasec/-/merge_requests/197

Check the following discussion https://odoo-community.org/groups/contributors-15/contributors-186006?mode=thread&date_begin=&date_end=

OpenBLAS creates a number of threads equal to the number of core threads available: 56 in my case (production server),
so it quickly reached limit_memory_hard
and the process was killed (SIGSEGV)
Forcing OPENBLAS_NUM_THREADS=1 fixed the issue.

Current behavior before PR:
Weird errors related to numpy.

Desired behavior after PR is merged:
No errors related to numpy.

Close #85 

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
